### PR TITLE
fix: update title scraper to look for an h2 on pages with video

### DIFF
--- a/substack_scraper.py
+++ b/substack_scraper.py
@@ -181,7 +181,7 @@ class BaseSubstackScraper(ABC):
 
         if standard_title:
             title = standard_title.text.strip()
-        elif video_title:
+        if video_title:
             title = video_title.text.strip()
         else:
             title = "Title not available"
@@ -189,7 +189,7 @@ class BaseSubstackScraper(ABC):
         subtitle_element = soup.select_one("h3.subtitle")
         subtitle = subtitle_element.text.strip() if subtitle_element else ""
 
-        date_selector = ".pencraft.pc-display-flex.pc-gap-4.pc-reset .pencraft"
+        date_selector = ".byline-wrapper .pencraft.pc-flexDirection-column div.pc-display-flex div"
         date_element = soup.select_one(date_selector)
         date = date_element.text.strip() if date_element else "Date not available"
 

--- a/substack_scraper.py
+++ b/substack_scraper.py
@@ -241,7 +241,7 @@ class BaseSubstackScraper(ABC):
                 else:
                     print(f"File already exists: {filepath}")
             except Exception as e:
-                print(f"Error scraping post at {url}: {e}")
+                print(f"Error scraping post: {e}")
             count += 1
             if num_posts_to_scrape != 0 and count == num_posts_to_scrape:
                 break

--- a/substack_scraper.py
+++ b/substack_scraper.py
@@ -176,7 +176,16 @@ class BaseSubstackScraper(ABC):
         """
         Converts substack post soup to markdown, returns metadata and content
         """
-        title = soup.select_one("h1.post-title, h2").text.strip()
+        standard_title = soup.select_one("h1.post-title, h2")
+        video_title = soup.select_one("h2")
+
+        if standard_title:
+            title = standard_title.text.strip()
+        elif video_title:
+            title = video_title.text.strip()
+        else:
+            title = "Title not available"
+
         subtitle_element = soup.select_one("h3.subtitle")
         subtitle = subtitle_element.text.strip() if subtitle_element else ""
 

--- a/substack_scraper.py
+++ b/substack_scraper.py
@@ -176,7 +176,7 @@ class BaseSubstackScraper(ABC):
         """
         Converts substack post soup to markdown, returns metadata and content
         """
-        title = soup.select_one("h1.post-title").text.strip()
+        title = soup.select_one("h1.post-title, h2").text.strip()
         subtitle_element = soup.select_one("h3.subtitle")
         subtitle = subtitle_element.text.strip() if subtitle_element else ""
 
@@ -241,7 +241,7 @@ class BaseSubstackScraper(ABC):
                 else:
                     print(f"File already exists: {filepath}")
             except Exception as e:
-                print(f"Error scraping post: {e}")
+                print(f"Error scraping post at {url}: {e}")
             count += 1
             if num_posts_to_scrape != 0 and count == num_posts_to_scrape:
                 break


### PR DESCRIPTION
This PR fixes an issue with the scraper that returned an empty node on pages with video, causing the scraper to skip over those pages. It also fixes an issue with the date selector not returning.