### PR TITLE
Improve: Add venv to .gitignore for smoother collaboration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /substack_md_files
 config.py
 setup.py
+venv

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 config.py
 setup.py
 venv
+**/__pycache__/
+data/*
+!data/README.md
+substack_html_pages/*
+!substack_html_pages/README.md


### PR DESCRIPTION
Hey @timf34,

This PR refines our .gitignore file to exclude unnecessary files and directories from version control, including:

- Virtual environment (venv) directory
- Personal contents of the data and substack_html_pages directories (except for README.md)

These changes will help avoid conflicts caused by differing developer environments, simplify onboarding for new contributors, and keep the repository lean.