### PR TITLE
Fix: Date retrieval and zero like count display issues

### DIFF
--- a/substack_scraper.py
+++ b/substack_scraper.py
@@ -20,18 +20,30 @@ from selenium.webdriver.chrome.service import Service
 from urllib.parse import urlparse
 from config import EMAIL, PASSWORD
 
-USE_PREMIUM: bool = False  # Set to True if you want to login to Substack and convert paid for posts
-BASE_SUBSTACK_URL: str = "https://www.thefitzwilliam.com/"  # Substack you want to convert to markdown
-BASE_MD_DIR: str = "substack_md_files"  # Name of the directory we'll save the .md essay files
-BASE_HTML_DIR: str = "substack_html_pages"  # Name of the directory we'll save the .html essay files
+USE_PREMIUM: bool = (
+    False  # Set to True if you want to login to Substack and convert paid for posts
+)
+BASE_SUBSTACK_URL: str = (
+    "https://www.thefitzwilliam.com/"  # Substack you want to convert to markdown
+)
+BASE_MD_DIR: str = (
+    "substack_md_files"  # Name of the directory we'll save the .md essay files
+)
+BASE_HTML_DIR: str = (
+    "substack_html_pages"  # Name of the directory we'll save the .html essay files
+)
 HTML_TEMPLATE: str = "author_template.html"  # HTML template to use for the author page
 JSON_DATA_DIR: str = "data"
 NUM_POSTS_TO_SCRAPE: int = 3  # Set to 0 if you want all posts
 
 
 def extract_main_part(url: str) -> str:
-    parts = urlparse(url).netloc.split('.')  # Parse the URL to get the netloc, and split on '.'
-    return parts[1] if parts[0] == 'www' else parts[0]  # Return the main part of the domain, while ignoring 'www' if
+    parts = urlparse(url).netloc.split(
+        "."
+    )  # Parse the URL to get the netloc, and split on '.'
+    return (
+        parts[1] if parts[0] == "www" else parts[0]
+    )  # Return the main part of the domain, while ignoring 'www' if
     # present
 
 
@@ -43,28 +55,26 @@ def generate_html_file(author_name: str) -> None:
         os.makedirs(BASE_HTML_DIR)
 
     # Read JSON data
-    json_path = os.path.join(JSON_DATA_DIR, f'{author_name}.json')
-    with open(json_path, 'r', encoding='utf-8') as file:
+    json_path = os.path.join(JSON_DATA_DIR, f"{author_name}.json")
+    with open(json_path, "r", encoding="utf-8") as file:
         essays_data = json.load(file)
 
     # Convert JSON data to a JSON string for embedding
     embedded_json_data = json.dumps(essays_data, ensure_ascii=False, indent=4)
 
-    with open(HTML_TEMPLATE, 'r', encoding='utf-8') as file:
+    with open(HTML_TEMPLATE, "r", encoding="utf-8") as file:
         html_template = file.read()
 
     # Insert the JSON string into the script tag in the HTML template
-    html_with_data = html_template.replace(
-        '<!-- AUTHOR_NAME -->', author_name
-    ).replace(
+    html_with_data = html_template.replace("<!-- AUTHOR_NAME -->", author_name).replace(
         '<script type="application/json" id="essaysData"></script>',
-        f'<script type="application/json" id="essaysData">{embedded_json_data}</script>'
+        f'<script type="application/json" id="essaysData">{embedded_json_data}</script>',
     )
-    html_with_author = html_with_data.replace('author_name', author_name)
+    html_with_author = html_with_data.replace("author_name", author_name)
 
     # Write the modified HTML to a new file
-    html_output_path = os.path.join(BASE_HTML_DIR, f'{author_name}.html')
-    with open(html_output_path, 'w', encoding='utf-8') as file:
+    html_output_path = os.path.join(BASE_HTML_DIR, f"{author_name}.html")
+    with open(html_output_path, "w", encoding="utf-8") as file:
         file.write(html_with_author)
 
 
@@ -107,29 +117,34 @@ class BaseSubstackScraper(ABC):
         response = requests.get(sitemap_url)
 
         if not response.ok:
-            print(f'Error fetching sitemap at {sitemap_url}: {response.status_code}')
+            print(f"Error fetching sitemap at {sitemap_url}: {response.status_code}")
             return []
 
         root = ET.fromstring(response.content)
-        urls = [element.text for element in root.iter('{http://www.sitemaps.org/schemas/sitemap/0.9}loc')]
+        urls = [
+            element.text
+            for element in root.iter("{http://www.sitemaps.org/schemas/sitemap/0.9}loc")
+        ]
         return urls
 
     def fetch_urls_from_feed(self) -> List[str]:
         """
         Fetches URLs from feed.xml.
         """
-        print('Falling back to feed.xml. This will only contain up to the 22 most recent posts.')
+        print(
+            "Falling back to feed.xml. This will only contain up to the 22 most recent posts."
+        )
         feed_url = f"{self.base_substack_url}feed.xml"
         response = requests.get(feed_url)
 
         if not response.ok:
-            print(f'Error fetching feed at {feed_url}: {response.status_code}')
+            print(f"Error fetching feed at {feed_url}: {response.status_code}")
             return []
 
         root = ET.fromstring(response.content)
         urls = []
-        for item in root.findall('.//item'):
-            link = item.find('link')
+        for item in root.findall(".//item"):
+            link = item.find("link")
             if link is not None and link.text:
                 urls.append(link.text)
 
@@ -169,17 +184,16 @@ class BaseSubstackScraper(ABC):
             print(f"File already exists: {filepath}")
             return
 
-        with open(filepath, 'w', encoding='utf-8') as file:
+        with open(filepath, "w", encoding="utf-8") as file:
             file.write(content)
-            
+
     @staticmethod
     def md_to_html(md_content: str) -> str:
         """
         This method converts Markdown to HTML
         """
-        return markdown.markdown(md_content, extensions=['extra'])
-    
-    
+        return markdown.markdown(md_content, extensions=["extra"])
+
     def save_to_html_file(self, filepath: str, content: str) -> None:
         """
         This method saves HTML content to a file with a link to an external CSS file.
@@ -212,7 +226,7 @@ class BaseSubstackScraper(ABC):
             </html>
         """
 
-        with open(filepath, 'w', encoding='utf-8') as file:
+        with open(filepath, "w", encoding="utf-8") as file:
             file.write(html_content)
 
     @staticmethod
@@ -232,7 +246,9 @@ class BaseSubstackScraper(ABC):
         return url.split("/")[-1] + filetype
 
     @staticmethod
-    def combine_metadata_and_content(title: str, subtitle: str, date: str, like_count: str, content) -> str:
+    def combine_metadata_and_content(
+        title: str, subtitle: str, date: str, like_count: str, content
+    ) -> str:
         """
         Combines the title, subtitle, and content into a single string with Markdown format
         """
@@ -254,21 +270,31 @@ class BaseSubstackScraper(ABC):
         """
         Converts substack post soup to markdown, returns metadata and content
         """
-        title = soup.select_one("h1.post-title, h2").text.strip()  # When a video is present, the title is demoted to h2
+        title = soup.select_one(
+            "h1.post-title, h2"
+        ).text.strip()  # When a video is present, the title is demoted to h2
 
         subtitle_element = soup.select_one("h3.subtitle")
         subtitle = subtitle_element.text.strip() if subtitle_element else ""
 
-        date_selector = ".pencraft.pc-display-flex.pc-gap-4.pc-reset .pencraft"
-        date_element = soup.select_one(date_selector)
-        date = date_element.text.strip() if date_element else "Date not available"
+        date_element = soup.find(
+            "div",
+            class_="pencraft pc-reset _color-pub-secondary-text_3axfk_207 _line-height-20_3axfk_95 _font-meta_3axfk_131 _size-11_3axfk_35 _weight-medium_3axfk_162 _transform-uppercase_3axfk_242 _reset_3axfk_1 _meta_3axfk_442",
+        )
+        date = date_element.text.strip() if date_element else "Date not found"
 
         like_count_element = soup.select_one("a.post-ufi-button .label")
-        like_count = like_count_element.text.strip() if like_count_element else "Like count not available"
+        like_count = (
+            like_count_element.text.strip()
+            if like_count_element and like_count_element.text.strip().isdigit()
+            else "0"
+        )
 
         content = str(soup.select_one("div.available-content"))
         md = self.html_to_md(content)
-        md_content = self.combine_metadata_and_content(title, subtitle, date, like_count, md)
+        md_content = self.combine_metadata_and_content(
+            title, subtitle, date, like_count, md
+        )
         return title, subtitle, like_count, date, md_content
 
     @abstractmethod
@@ -283,12 +309,14 @@ class BaseSubstackScraper(ABC):
         if not os.path.exists(data_dir):
             os.makedirs(data_dir)
 
-        json_path = os.path.join(data_dir, f'{self.writer_name}.json')
+        json_path = os.path.join(data_dir, f"{self.writer_name}.json")
         if os.path.exists(json_path):
-            with open(json_path, 'r', encoding='utf-8') as file:
+            with open(json_path, "r", encoding="utf-8") as file:
                 existing_data = json.load(file)
-            essays_data = existing_data + [data for data in essays_data if data not in existing_data]
-        with open(json_path, 'w', encoding='utf-8') as f:
+            essays_data = existing_data + [
+                data for data in essays_data if data not in existing_data
+            ]
+        with open(json_path, "w", encoding="utf-8") as f:
             json.dump(essays_data, f, ensure_ascii=False, indent=4)
 
     def scrape_posts(self, num_posts_to_scrape: int = 0) -> None:
@@ -304,7 +332,7 @@ class BaseSubstackScraper(ABC):
                 html_filename = self.get_filename_from_url(url, filetype=".html")
                 md_filepath = os.path.join(self.md_save_dir, md_filename)
                 html_filepath = os.path.join(self.html_save_dir, html_filename)
-                
+
                 if not os.path.exists(md_filepath):
                     soup = self.get_url_soup(url)
                     if soup is None:
@@ -312,19 +340,21 @@ class BaseSubstackScraper(ABC):
                         continue
                     title, subtitle, like_count, date, md = self.extract_post_data(soup)
                     self.save_to_file(md_filepath, md)
-                    
+
                     # Convert markdown to HTML and save
                     html_content = self.md_to_html(md)
                     self.save_to_html_file(html_filepath, html_content)
-                    
-                    essays_data.append({
-                        "title": title,
-                        "subtitle": subtitle,
-                        "like_count": like_count,
-                        "date": date,
-                        "file_link": md_filepath,
-                        "html_link": html_filepath
-                    })
+
+                    essays_data.append(
+                        {
+                            "title": title,
+                            "subtitle": subtitle,
+                            "like_count": like_count,
+                            "date": date,
+                            "file_link": md_filepath,
+                            "html_link": html_filepath,
+                        }
+                    )
                 else:
                     print(f"File already exists: {md_filepath}")
             except Exception as e:
@@ -357,14 +387,14 @@ class SubstackScraper(BaseSubstackScraper):
 
 class PremiumSubstackScraper(BaseSubstackScraper):
     def __init__(
-            self,
-            base_substack_url: str,
-            md_save_dir: str,
-            html_save_dir: str,
-            headless: bool = False,
-            edge_path: str = '',
-            edge_driver_path: str = '',
-            user_agent: str = ''
+        self,
+        base_substack_url: str,
+        md_save_dir: str,
+        html_save_dir: str,
+        headless: bool = False,
+        edge_path: str = "",
+        edge_driver_path: str = "",
+        user_agent: str = "",
     ) -> None:
         super().__init__(base_substack_url, md_save_dir, html_save_dir)
 
@@ -374,8 +404,9 @@ class PremiumSubstackScraper(BaseSubstackScraper):
         if edge_path:
             options.binary_location = edge_path
         if user_agent:
-            options.add_argument(f'user-agent={user_agent}')  # Pass this if running headless and blocked by captcha
-
+            options.add_argument(
+                f"user-agent={user_agent}"
+            )  # Pass this if running headless and blocked by captcha
 
         if edge_driver_path:
             service = Service(executable_path=edge_driver_path)
@@ -405,20 +436,24 @@ class PremiumSubstackScraper(BaseSubstackScraper):
         password.send_keys(PASSWORD)
 
         # Find the submit button and click it.
-        submit = self.driver.find_element(By.XPATH, "//*[@id=\"substack-login\"]/div[2]/div[2]/form/button")
+        submit = self.driver.find_element(
+            By.XPATH, '//*[@id="substack-login"]/div[2]/div[2]/form/button'
+        )
         submit.click()
         sleep(30)  # Wait for the page to load
 
         if self.is_login_failed():
-            raise Exception("Warning: Login unsuccessful. Please check your email and password, or your account status.\n"
-                  "Use the non-premium scraper for the non-paid posts. \n"
-                  "If running headless, run non-headlessly to see if blocked by Captcha.")
+            raise Exception(
+                "Warning: Login unsuccessful. Please check your email and password, or your account status.\n"
+                "Use the non-premium scraper for the non-paid posts. \n"
+                "If running headless, run non-headlessly to see if blocked by Captcha."
+            )
 
     def is_login_failed(self) -> bool:
         """
         Check for the presence of the 'error-container' to indicate a failed login attempt.
         """
-        error_container = self.driver.find_elements(By.ID, 'error-container')
+        error_container = self.driver.find_elements(By.ID, "error-container")
         return len(error_container) > 0 and error_container[0].is_displayed()
 
     def get_url_soup(self, url: str) -> BeautifulSoup:
@@ -433,27 +468,56 @@ class PremiumSubstackScraper(BaseSubstackScraper):
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description='Scrape a Substack site.')
-    parser.add_argument('-u', '--url', type=str,
-                        help='The base URL of the Substack site to scrape.')
-    parser.add_argument('-d', '--directory', type=str,
-                        help='The directory to save scraped posts.')
-    parser.add_argument('-n', '--number', type=int, default=0,
-                        help='The number of posts to scrape. If 0 or not provided, all posts will be scraped.')
-    parser.add_argument('-p', '--premium', action='store_true',
-                        help='Include -p in command to use the Premium Substack Scraper with selenium.')
-    parser.add_argument('--headless', action='store_true',
-                        help='Include -h in command to run browser in headless mode when using the Premium Substack '
-                             'Scraper.')
-    parser.add_argument('--edge-path', type=str, default='',
-                        help='Optional: The path to the Edge browser executable (i.e. "path_to_msedge.exe").')
-    parser.add_argument('--edge-driver-path', type=str, default='',
-                        help='Optional: The path to the Edge WebDriver executable (i.e. "path_to_msedgedriver.exe").')
-    parser.add_argument('--user-agent', type=str, default='',
-                        help='Optional: Specify a custom user agent for selenium browser automation. Useful for '
-                             'passing captcha in headless mode')
-    parser.add_argument('--html-directory', type=str,
-                        help='The directory to save scraped posts as HTML files.')
+    parser = argparse.ArgumentParser(description="Scrape a Substack site.")
+    parser.add_argument(
+        "-u", "--url", type=str, help="The base URL of the Substack site to scrape."
+    )
+    parser.add_argument(
+        "-d", "--directory", type=str, help="The directory to save scraped posts."
+    )
+    parser.add_argument(
+        "-n",
+        "--number",
+        type=int,
+        default=0,
+        help="The number of posts to scrape. If 0 or not provided, all posts will be scraped.",
+    )
+    parser.add_argument(
+        "-p",
+        "--premium",
+        action="store_true",
+        help="Include -p in command to use the Premium Substack Scraper with selenium.",
+    )
+    parser.add_argument(
+        "--headless",
+        action="store_true",
+        help="Include -h in command to run browser in headless mode when using the Premium Substack "
+        "Scraper.",
+    )
+    parser.add_argument(
+        "--edge-path",
+        type=str,
+        default="",
+        help='Optional: The path to the Edge browser executable (i.e. "path_to_msedge.exe").',
+    )
+    parser.add_argument(
+        "--edge-driver-path",
+        type=str,
+        default="",
+        help='Optional: The path to the Edge WebDriver executable (i.e. "path_to_msedgedriver.exe").',
+    )
+    parser.add_argument(
+        "--user-agent",
+        type=str,
+        default="",
+        help="Optional: Specify a custom user agent for selenium browser automation. Useful for "
+        "passing captcha in headless mode",
+    )
+    parser.add_argument(
+        "--html-directory",
+        type=str,
+        help="The directory to save scraped posts as HTML files.",
+    )
 
     return parser.parse_args()
 
@@ -469,9 +533,16 @@ def main():
 
     if args.url:
         if args.premium:
-            scraper = PremiumSubstackScraper(args.url, headless=args.headless, md_save_dir=args.directory, html_save_dir=args.html_directory)
+            scraper = PremiumSubstackScraper(
+                args.url,
+                headless=args.headless,
+                md_save_dir=args.directory,
+                html_save_dir=args.html_directory,
+            )
         else:
-            scraper = SubstackScraper(args.url, md_save_dir=args.directory, html_save_dir=args.html_directory)
+            scraper = SubstackScraper(
+                args.url, md_save_dir=args.directory, html_save_dir=args.html_directory
+            )
         scraper.scrape_posts(args.number)
 
     else:  # Use the hardcoded values at the top of the file
@@ -481,10 +552,14 @@ def main():
                 md_save_dir=args.directory,
                 html_save_dir=args.html_directory,
                 edge_path=args.edge_path,
-                edge_driver_path=args.edge_driver_path
+                edge_driver_path=args.edge_driver_path,
             )
         else:
-            scraper = SubstackScraper(base_substack_url=BASE_SUBSTACK_URL, md_save_dir=args.directory, html_save_dir=args.html_directory)
+            scraper = SubstackScraper(
+                base_substack_url=BASE_SUBSTACK_URL,
+                md_save_dir=args.directory,
+                html_save_dir=args.html_directory,
+            )
         scraper.scrape_posts(num_posts_to_scrape=NUM_POSTS_TO_SCRAPE)
 
 


### PR DESCRIPTION
## This PR fixes two issues
- Incorrect date retrieval caused by an incorrect date_element selector.
- Zero like count display error due to fetching the "share" label when the actual like count is 0.

## Effect of this change
### date retrieval (before)
<img width="1920" alt="date-before" src="https://github.com/user-attachments/assets/7b035473-2b6b-4483-907b-28b507ab19ef">

### date retrieval (after)
<img width="1920" alt="date-after" src="https://github.com/user-attachments/assets/6d66c50f-5e15-4361-bcbc-84c36799e50a">

### zero like count display (before)
![like-before](https://github.com/user-attachments/assets/0efc1883-3cd4-4354-a044-0df4b641aa9f)

### zero like count display (after)
<img width="1920" alt="like-after" src="https://github.com/user-attachments/assets/d82e4995-0915-4b16-bdd5-b2a568acbcef">

## Why were so many lines of code affected?
While only 10 lines of code were functionally changed, the remaining modifications were purely stylistic, applied by the [Black](https://github.com/psf/black) formatter with its default configuration.