### PR TITLE
Add online version option to enhance user accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ﻿# Substack2Markdown
 
 Substack2Markdown is a Python tool for downloading free and premium Substack posts and saving them as both Markdown and HTML
-files. It will save paid for content as long as you're subscribed to that substack. Most "save for later" apps (such 
-as Pocket) don't save these posts, but with this script you can now browse and sort through these posts in a 
-user-friendly HTML interface.
+files. It will save paid for content as long as you're subscribed to that substack.
+
+> 🆕 ✨ Now available online! Try our web version at [Substack Reader](https://www.substacktools.com/reader) - no installation required!
 
 ![Substack2Markdown Interface](./assets/images/screenshot.png)
 
@@ -20,6 +20,7 @@ specify them as command line arguments.
 - Generates an HTML file to browse Markdown files.
 - Supports free and premium content (with subscription).
 - The HTML interface allows sorting essays by date or likes.
+- Online version available at [Substack Reader](https://www.substacktools.com/reader) - no local setup required!
 
 ## Installation
 
@@ -74,8 +75,20 @@ To scrape a specific number of posts:
 python substack_scraper.py --url https://example.substack.com --directory /path/to/save/posts --number 5
 ```
 
+### Online Version
+
+For a hassle-free experience without any local setup:
+
+1. Visit [Substack Reader](https://www.substacktools.com/reader)
+2. Enter the Substack URL you want to read or export
+3. Click "Go" to instantly view the content or "Export" to download Markdown files
+
+This online version provides a user-friendly web interface for reading and exporting free Substack articles, with no installation required. However, please note that the online version currently does not support exporting premium content. For full functionality, including premium content export, please use the local script as described above.
+
 ## Viewing Markdown Files in Browser
 
 To read the Markdown files in your browser, install the [Markdown Viewer](https://chromewebstore.google.com/detail/markdown-viewer/ckkdlimhmcjmikdlpkmbgfkaikojcbjk)
 browser extension. But note, we also save the files as HTML for easy viewing, 
 just set the toggle to HTML on the author homepage. 
+
+Or you can use our [Substack Reader](https://www.substacktools.com/reader) online tool, which allows you to read and export free Substack articles directly in your browser. (Note: Premium content export is currently only available in the local script version)


### PR DESCRIPTION
Hi @timf34!

Inspired by Substack2Markdown, I've developed an online version and would like to add information about it to the README. This addition aims to provide users with a no-setup option, potentially broadening the tool's accessibility.

Key changes:
1. Added brief mentions of the online version in the Features and Introduction
2. Included an "Online Version" subsection in the Usage section
3. Updated "Viewing Markdown Files in Browser" to include the online option

The online version is presented as a complementary tool, with clear indications of its current limitations (e.g., no support for premium content export). The online version is totally free and added a back link to this open-source project.

The online version is presented as a complementary tool, with clear indications of its current limitations (e.g., no support for premium content export). The online version is totally free and added a back link to this open-source project.

<img width="1490" alt="page-1" src="https://github.com/user-attachments/assets/5d27275e-7036-4187-af6a-758353890125">
<img width="1512" alt="page-2" src="https://github.com/user-attachments/assets/ea2de5c6-e9ed-41c7-8d08-5f895cade779">
<img width="1500" alt="page-3" src="https://github.com/user-attachments/assets/b0f27276-abd7-40d9-ad47-5bdcd4e28f6f">

I believe this addition will make the project more accessible to users who prefer web-based solutions. I'm open to any feedback to improve this PR.

Thank you for your consideration.