### PR TITLE
Add option to download images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ substack_html_pages/*
 
 # Ignore substack_md_files directory
 /substack_md_files/
+
+# Ignore downloaded image assets
+substack_images/

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ specify them as command line arguments.
 - Converts Substack posts into Markdown files.
 - Generates an HTML file to browse Markdown files.
 - Supports free and premium content (with subscription).
+- Supports scraping a single post URL directly (for example, `/p/my-post`).
+- Can download Substack-hosted images locally with `--images`.
 - The HTML interface allows sorting essays by date or likes.
 
 ## Installation
@@ -69,6 +71,18 @@ For premium Substack sites:
 
 ```bash
 python substack_scraper.py --url https://example.substack.com --directory /path/to/save/posts --premium
+```
+
+To scrape a single post directly:
+
+```bash
+python substack_scraper.py --url https://example.substack.com/p/my-post
+```
+
+To download images locally and rewrite markdown image links:
+
+```bash
+python substack_scraper.py --url https://example.substack.com --images
 ```
 
 To scrape a specific number of posts:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ selenium==4.16.0
 tqdm==4.66.1
 webdriver_manager==4.0.1
 Markdown==3.6
+pytest==8.3.4

--- a/substack_scraper.py
+++ b/substack_scraper.py
@@ -1,5 +1,7 @@
 import argparse
+import hashlib
 import json
+import mimetypes
 import os
 import random
 import re
@@ -7,6 +9,8 @@ import shutil
 import subprocess
 import sys
 from abc import ABC, abstractmethod
+from pathlib import Path
+from urllib.parse import unquote, urlparse
 from typing import List, Optional, Tuple
 from time import sleep
 
@@ -32,13 +36,112 @@ USE_PREMIUM: bool = True
 BASE_SUBSTACK_URL: str = "https://niallferguson.substack.com/"
 BASE_MD_DIR: str = "substack_md_files"
 BASE_HTML_DIR: str = "substack_html_pages"
+BASE_IMAGE_DIR: str = "substack_images"
 HTML_TEMPLATE: str = "author_template.html"
 JSON_DATA_DIR: str = "data"
 NUM_POSTS_TO_SCRAPE: int = 0
 
 
+def resolve_image_url(url: str) -> str:
+    """Get the original image URL from a Substack CDN URL."""
+    if url.startswith("https://substackcdn.com/image/fetch/"):
+        parts = url.split("/https%3A%2F%2F")
+        if len(parts) > 1:
+            url = "https://" + unquote(parts[1])
+    return url
+
+
+def clean_linked_images(md_content: str) -> str:
+    """Converts markdown linked images [![alt](img)](link) to ![alt](img)."""
+    pattern = r'\[!\[(.*?)\]\((.*?)\)\]\(.*?\)'
+    return re.sub(pattern, r'![\1](\2)', md_content)
+
+
+def count_images_in_markdown(md_content: str) -> int:
+    """Count number of image references in markdown content."""
+    cleaned_content = clean_linked_images(md_content)
+    pattern = r'!\[.*?\]\((.*?)\)'
+    matches = re.findall(pattern, cleaned_content)
+    return len(matches)
+
+
+def is_post_url(url: str) -> bool:
+    """Check if URL points to a specific post (contains /p/)."""
+    return "/p/" in url
+
+
+def get_publication_url(url: str) -> str:
+    """Extract the base publication URL from a post URL."""
+    parsed = urlparse(url)
+    return f"{parsed.scheme}://{parsed.netloc}/"
+
+
+def get_post_slug(url: str) -> str:
+    """Extract the post slug from a Substack post URL."""
+    match = re.search(r'/p/([^/]+)', url)
+    return match.group(1) if match else 'unknown_post'
+
+
+def sanitize_image_filename(url: str) -> str:
+    """Create a safe filename from an image URL."""
+    url = resolve_image_url(url)
+    filename = url.split("/")[-1]
+    filename = filename.split("?")[0]
+    filename = re.sub(r'[<>:"/\\|?*]', '', filename)
+
+    if len(filename) > 100 or not filename:
+        hash_object = hashlib.md5(url.encode())
+        ext = mimetypes.guess_extension(
+            requests.head(url).headers.get('content-type', '')
+        ) or '.jpg'
+        filename = f"{hash_object.hexdigest()}{ext}"
+
+    return filename
+
+
+def download_image(url: str, save_path: Path, pbar=None) -> Optional[str]:
+    """Download image from URL and save to path."""
+    try:
+        response = requests.get(url, stream=True)
+        if response.status_code == 200:
+            save_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(save_path, 'wb') as f:
+                for chunk in response.iter_content(chunk_size=8192):
+                    if chunk:
+                        f.write(chunk)
+            if pbar:
+                pbar.update(1)
+            return str(save_path)
+    except Exception as e:
+        msg = f"Error downloading image {url}: {str(e)}"
+        if pbar:
+            pbar.write(msg)
+        else:
+            print(msg)
+    return None
+
+
+def process_markdown_images(md_content: str, author: str, post_slug: str, pbar=None) -> str:
+    """Process markdown content to download images and update references."""
+    image_dir = Path(BASE_IMAGE_DIR) / author / post_slug
+    md_content = clean_linked_images(md_content)
+
+    def replace_image(match):
+        url = match.group(0).strip('()')
+        resolved_url = resolve_image_url(url)
+        filename = sanitize_image_filename(url)
+        save_path = image_dir / filename
+        if not save_path.exists():
+            download_image(resolved_url, save_path, pbar)
+
+        rel_path = os.path.relpath(save_path, Path(BASE_MD_DIR) / author)
+        return f"({rel_path})"
+
+    pattern = r'\(https://substackcdn\.com/image/fetch/[^\s\)]+\)'
+    return re.sub(pattern, replace_image, md_content)
+
+
 def extract_main_part(url: str) -> str:
-    from urllib.parse import urlparse
     parts = urlparse(url).netloc.split('.')
     return parts[1] if parts[0] == 'www' else parts[0]
 
@@ -623,7 +726,20 @@ class BrowserManager:
 # =============================================================================
 
 class BaseSubstackScraper(ABC):
-    def __init__(self, base_substack_url: str, md_save_dir: str, html_save_dir: str):
+    def __init__(
+        self,
+        base_substack_url: str,
+        md_save_dir: str,
+        html_save_dir: str,
+        download_images: bool = False,
+    ):
+        self.is_single_post: bool = is_post_url(base_substack_url)
+        self.post_slug: Optional[str] = get_post_slug(base_substack_url) if self.is_single_post else None
+        original_url = base_substack_url
+
+        if self.is_single_post:
+            base_substack_url = get_publication_url(base_substack_url)
+
         if not base_substack_url.endswith("/"):
             base_substack_url += "/"
         self.base_substack_url: str = base_substack_url
@@ -641,8 +757,14 @@ class BaseSubstackScraper(ABC):
             os.makedirs(self.html_save_dir)
             print(f"Created html directory {self.html_save_dir}")
 
-        self.keywords: List[str] = ["about", "archive", "podcast"]
-        self.post_urls: List[str] = self.get_all_post_urls()
+        self.download_images: bool = download_images
+        self.image_dir = Path(BASE_IMAGE_DIR) / self.writer_name
+
+        if self.is_single_post:
+            self.post_urls: List[str] = [original_url]
+        else:
+            self.keywords: List[str] = ["about", "archive", "podcast"]
+            self.post_urls: List[str] = self.get_all_post_urls()
 
     def get_all_post_urls(self) -> List[str]:
         """Attempts to fetch URLs from sitemap.xml, falling back to feed.xml if necessary."""
@@ -845,39 +967,55 @@ class BaseSubstackScraper(ABC):
         essays_data = []
         count = 0
         total = num_posts_to_scrape if num_posts_to_scrape != 0 else len(self.post_urls)
-        for url in tqdm(self.post_urls, total=total):
-            try:
-                md_filename = self.get_filename_from_url(url, filetype=".md")
-                html_filename = self.get_filename_from_url(url, filetype=".html")
-                md_filepath = os.path.join(self.md_save_dir, md_filename)
-                html_filepath = os.path.join(self.html_save_dir, html_filename)
+        with tqdm(total=total, desc="Scraping posts") as pbar:
+            for url in self.post_urls:
+                try:
+                    md_filename = self.get_filename_from_url(url, filetype=".md")
+                    html_filename = self.get_filename_from_url(url, filetype=".html")
+                    md_filepath = os.path.join(self.md_save_dir, md_filename)
+                    html_filepath = os.path.join(self.html_save_dir, html_filename)
 
-                if not os.path.exists(md_filepath):
-                    soup = self.get_url_soup(url)
-                    if soup is None:
-                        total += 1
-                        continue
-                    title, subtitle, like_count, date, md = self.extract_post_data(soup)
-                    self.save_to_file(md_filepath, md)
+                    if not os.path.exists(md_filepath):
+                        soup = self.get_url_soup(url)
+                        if soup is None:
+                            total += 1
+                            pbar.total = total
+                            pbar.refresh()
+                            continue
 
-                    html_content = self.md_to_html(md)
-                    self.save_to_html_file(html_filepath, html_content)
+                        title, subtitle, like_count, date, md = self.extract_post_data(soup)
 
-                    essays_data.append({
-                        "title": title,
-                        "subtitle": subtitle,
-                        "like_count": like_count,
-                        "date": date,
-                        "file_link": md_filepath,
-                        "html_link": html_filepath
-                    })
-                else:
-                    print(f"File already exists: {md_filepath}")
-            except Exception as e:
-                print(f"Error scraping post: {e}")
-            count += 1
-            if num_posts_to_scrape != 0 and count == num_posts_to_scrape:
-                break
+                        if self.download_images:
+                            total_images = count_images_in_markdown(md)
+                            slug = get_post_slug(url) if is_post_url(url) else url.rstrip('/').split('/')[-1]
+                            with tqdm(
+                                total=total_images,
+                                desc=f"Downloading images for {slug}",
+                                leave=False,
+                            ) as img_pbar:
+                                md = process_markdown_images(md, self.writer_name, slug, img_pbar)
+
+                        self.save_to_file(md_filepath, md)
+                        html_content = self.md_to_html(md)
+                        self.save_to_html_file(html_filepath, html_content)
+
+                        essays_data.append({
+                            "title": title,
+                            "subtitle": subtitle,
+                            "like_count": like_count,
+                            "date": date,
+                            "file_link": md_filepath,
+                            "html_link": html_filepath
+                        })
+                    else:
+                        pbar.write(f"File already exists: {md_filepath}")
+                except Exception as e:
+                    pbar.write(f"Error scraping post: {e}")
+
+                count += 1
+                pbar.update(1)
+                if num_posts_to_scrape != 0 and count == num_posts_to_scrape:
+                    break
         self.save_essays_data_to_json(essays_data=essays_data)
         generate_html_file(author_name=self.writer_name)
 
@@ -887,8 +1025,14 @@ class BaseSubstackScraper(ABC):
 # =============================================================================
 
 class SubstackScraper(BaseSubstackScraper):
-    def __init__(self, base_substack_url: str, md_save_dir: str, html_save_dir: str):
-        super().__init__(base_substack_url, md_save_dir, html_save_dir)
+    def __init__(
+        self,
+        base_substack_url: str,
+        md_save_dir: str,
+        html_save_dir: str,
+        download_images: bool = False,
+    ):
+        super().__init__(base_substack_url, md_save_dir, html_save_dir, download_images)
 
     def get_url_soup(self, url: str, max_attempts: int = 5) -> Optional[BeautifulSoup]:
         """Gets soup from URL using requests, with retry on rate limiting."""
@@ -930,6 +1074,7 @@ class PremiumSubstackScraper(BaseSubstackScraper):
         base_substack_url: str,
         md_save_dir: str,
         html_save_dir: str,
+        download_images: bool = False,
         browser: str = 'chrome',
         headless: bool = False,
         driver_path: str = '',
@@ -973,8 +1118,8 @@ class PremiumSubstackScraper(BaseSubstackScraper):
             # Navigate to substack to verify we're logged in
             self.driver.get(base_substack_url)
             sleep(3)
-        
-        super().__init__(base_substack_url, md_save_dir, html_save_dir)
+
+        super().__init__(base_substack_url, md_save_dir, html_save_dir, download_images)
 
     def login(self) -> None:
         """Log into Substack using Selenium."""
@@ -1096,6 +1241,11 @@ Examples:
         "-n", "--number", type=int, default=0,
         help="Number of posts to scrape (0 = all posts)."
     )
+    parser.add_argument(
+        "--images",
+        action="store_true",
+        help="Download images and update markdown to use local paths."
+    )
     
     # Premium scraping options
     premium_group = parser.add_argument_group('Premium scraping options')
@@ -1169,6 +1319,7 @@ def main():
                 base_substack_url=args.url,
                 md_save_dir=args.directory,
                 html_save_dir=args.html_directory,
+                download_images=args.images,
                 browser=args.browser,
                 headless=args.headless,
                 driver_path=driver_path,
@@ -1181,7 +1332,8 @@ def main():
             scraper = SubstackScraper(
                 args.url,
                 md_save_dir=args.directory,
-                html_save_dir=args.html_directory
+                html_save_dir=args.html_directory,
+                download_images=args.images,
             )
         scraper.scrape_posts(args.number)
 
@@ -1192,6 +1344,7 @@ def main():
                 base_substack_url=BASE_SUBSTACK_URL,
                 md_save_dir=args.directory,
                 html_save_dir=args.html_directory,
+                download_images=args.images,
                 browser=args.browser,
                 headless=args.headless,
                 driver_path=driver_path,
@@ -1204,7 +1357,8 @@ def main():
             scraper = SubstackScraper(
                 base_substack_url=BASE_SUBSTACK_URL,
                 md_save_dir=args.directory,
-                html_save_dir=args.html_directory
+                html_save_dir=args.html_directory,
+                download_images=args.images,
             )
         scraper.scrape_posts(num_posts_to_scrape=NUM_POSTS_TO_SCRAPE)
 

--- a/tests/test_substack_scraper.py
+++ b/tests/test_substack_scraper.py
@@ -1,0 +1,230 @@
+import os
+import sys
+import shutil
+
+import pytest
+from pathlib import Path
+from unittest.mock import Mock, patch, MagicMock
+
+import substack_scraper as ss
+
+
+class DummyScraper(ss.BaseSubstackScraper):
+    def get_url_soup(self, url: str):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Existing tests (preserved)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_image_url_extracts_original_url():
+    cdn_url = (
+        "https://substackcdn.com/image/fetch/w_1456,c_limit,f_webp,q_auto:good,"
+        "fl_progressive:steep/https%3A%2F%2Fbucket.s3.us-west-2.amazonaws.com%2Fimage.jpg"
+    )
+
+    assert ss.resolve_image_url(cdn_url) == "https://bucket.s3.us-west-2.amazonaws.com/image.jpg"
+
+
+def test_sanitize_image_filename_uses_resolved_url_name():
+    cdn_url = (
+        "https://substackcdn.com/image/fetch/w_1456,c_limit,f_webp,q_auto:good,"
+        "fl_progressive:steep/https%3A%2F%2Fbucket.s3.us-west-2.amazonaws.com%2Fimage.jpg%3Fv%3D1"
+    )
+
+    assert ss.sanitize_image_filename(cdn_url) == "image.jpg"
+
+
+def test_count_images_in_markdown_counts_cleaned_linked_images():
+    markdown = "[![alt](https://cdn/a.png)](https://example.com)\n\n![plain](https://cdn/b.png)"
+
+    assert ss.count_images_in_markdown(markdown) == 2
+
+
+def test_single_post_url_initializes_without_fetching_all_posts(tmp_path):
+    scraper = DummyScraper(
+        "https://example.substack.com/p/my-post",
+        str(tmp_path / "md"),
+        str(tmp_path / "html"),
+        download_images=True,
+    )
+
+    assert scraper.is_single_post is True
+    assert scraper.post_slug == "my-post"
+    assert scraper.base_substack_url == "https://example.substack.com/"
+    assert scraper.post_urls == ["https://example.substack.com/p/my-post"]
+    assert scraper.download_images is True
+
+
+def test_parse_args_supports_images_flag(monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["substack_scraper.py", "--url", "https://example.substack.com/p/post", "--images"],
+    )
+
+    args = ss.parse_args()
+
+    assert args.url == "https://example.substack.com/p/post"
+    assert args.images is True
+
+
+# ---------------------------------------------------------------------------
+# New tests
+# ---------------------------------------------------------------------------
+
+
+# 1. Parametrized test_clean_linked_images
+@pytest.mark.parametrize(
+    "input_md, expected",
+    [
+        pytest.param(
+            "[![Image 1](/img/test/image1.png)](/img/test/image1.png)",
+            "![Image 1](/img/test/image1.png)",
+            id="basic_cleaning",
+        ),
+        pytest.param(
+            "Check [this link](https://example.com) and [![photo](img.png)](img.png) and ![plain](other.png)",
+            "Check [this link](https://example.com) and ![photo](img.png) and ![plain](other.png)",
+            id="mixed_content",
+        ),
+        pytest.param(
+            "[![CDN](https://substackcdn.com/image/fetch/w_1456/https%3A%2F%2Fexample.com%2Fphoto.jpg)](https://substackcdn.com/image/fetch/w_1456/https%3A%2F%2Fexample.com%2Fphoto.jpg)",
+            "![CDN](https://substackcdn.com/image/fetch/w_1456/https%3A%2F%2Fexample.com%2Fphoto.jpg)",
+            id="substack_cdn_urls",
+        ),
+        pytest.param(
+            "![Already clean](https://example.com/img.png)",
+            "![Already clean](https://example.com/img.png)",
+            id="no_changes_needed",
+        ),
+        pytest.param(
+            "",
+            "",
+            id="empty_content",
+        ),
+        pytest.param(
+            "Line one\n\n[![img](a.png)](a.png)\n\nLine three",
+            "Line one\n\n![img](a.png)\n\nLine three",
+            id="preserve_newlines",
+        ),
+        pytest.param(
+            '[![Image with "quotes" & special](https://example.com/img%20file.png)](https://example.com/img%20file.png)',
+            '![Image with "quotes" & special](https://example.com/img%20file.png)',
+            id="special_characters",
+        ),
+    ],
+)
+def test_clean_linked_images(input_md, expected):
+    assert ss.clean_linked_images(input_md) == expected
+
+
+# 2. test_resolve_image_url_passthrough
+def test_resolve_image_url_passthrough():
+    """Non-CDN URLs should pass through unchanged."""
+    urls = [
+        "https://example.com/photo.jpg",
+        "https://bucket.s3.amazonaws.com/image.png",
+        "https://i.imgur.com/abc123.gif",
+        "/relative/path/image.png",
+    ]
+    for url in urls:
+        assert ss.resolve_image_url(url) == url
+
+
+# 3. test_is_post_url
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        ("https://example.substack.com/p/my-post", True),
+        ("https://example.substack.com/p/another-post-slug", True),
+        ("https://example.substack.com/", False),
+        ("https://example.substack.com/archive", False),
+        ("https://example.substack.com/about", False),
+    ],
+)
+def test_is_post_url(url, expected):
+    assert ss.is_post_url(url) == expected
+
+
+# 4. test_get_publication_url
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        ("https://example.substack.com/p/my-post", "https://example.substack.com/"),
+        ("https://blog.example.com/p/slug", "https://blog.example.com/"),
+        ("http://test.substack.com/p/post-name", "http://test.substack.com/"),
+    ],
+)
+def test_get_publication_url(url, expected):
+    assert ss.get_publication_url(url) == expected
+
+
+# 5. test_get_post_slug
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        ("https://example.substack.com/p/my-post", "my-post"),
+        ("https://example.substack.com/p/another-slug", "another-slug"),
+        ("https://example.substack.com/p/slug-with-123", "slug-with-123"),
+        ("https://example.substack.com/archive", "unknown_post"),
+    ],
+)
+def test_get_post_slug(url, expected):
+    assert ss.get_post_slug(url) == expected
+
+
+# 6. test_process_markdown_images
+@patch("substack_scraper.download_image")
+def test_process_markdown_images(mock_download):
+    """Mock requests.get and verify image download + path rewriting."""
+    mock_download.return_value = "substack_images/testauthor/test-post/photo.jpg"
+
+    md_content = (
+        "Some text\n"
+        "![alt](https://substackcdn.com/image/fetch/w_1456,c_limit/https%3A%2F%2Fexample.com%2Fphoto.jpg)\n"
+        "More text"
+    )
+
+    result = ss.process_markdown_images(md_content, "testauthor", "test-post")
+
+    # download_image should have been called once
+    assert mock_download.call_count == 1
+
+    # The CDN URL should be replaced with a local relative path
+    assert "substackcdn.com" not in result
+    assert "Some text" in result
+    assert "More text" in result
+
+
+# 7. test_download_image_error_handling
+@patch("substack_scraper.requests.get")
+def test_download_image_error_handling(mock_get, tmp_path):
+    """Mock network error, verify graceful handling (returns None)."""
+    mock_get.side_effect = ConnectionError("Network unreachable")
+
+    result = ss.download_image(
+        "https://example.com/image.jpg",
+        tmp_path / "image.jpg",
+    )
+
+    assert result is None
+
+
+# 8. test_scraper_initialization
+def test_scraper_initialization(tmp_path):
+    """Verify writer_name and directories are created."""
+    md_dir = str(tmp_path / "md")
+    html_dir = str(tmp_path / "html")
+
+    scraper = DummyScraper(
+        "https://example.substack.com/p/test-post",
+        md_dir,
+        html_dir,
+    )
+
+    assert scraper.writer_name == "example"
+    assert os.path.isdir(os.path.join(md_dir, "example"))
+    assert os.path.isdir(os.path.join(html_dir, "example"))


### PR DESCRIPTION
I'm using this tool to mirror some of my Substack posts to my website, and as part of that process I'd really like to host my own images instead of having them link to the Substack CDN!

In case this will help someone else, here's a PR 🙂 

Here's a list of some tweaks I made to get that to happen:
- Add an `--images` flag that will download images for all posts being scraped into a `substack_images/` folder
- Add an option to download a single post (by passing in a `--url` in the format `https://example.substack.com/p/postname`
- When downloading images, Substack nests them like `[![alt](/path)](/path)`. Change these to just be `![alt](/path)` so clicking on the images doesn't link to itself.
- Add some tests, to prove to myself this code works the way I expect it


As a bonus, the progress bars reflect image downloads (since they can take a while)!  As an example:
```
Scraping posts: 100%|██████████| 2/2 [00:30<00:00, 15.00s/post]
  Downloading images for test-post: 100%|██████████| 7/7 [00:14<00:00, 2.00s/image]
  Downloading images for another-post: 100%|██████████| 4/4 [00:08<00:00, 2.00s/image]
```