### PR TITLE
Fix CSS selectors to reflect latest changes in substack layout

### DIFF
--- a/substack_scraper.py
+++ b/substack_scraper.py
@@ -261,12 +261,12 @@ class BaseSubstackScraper(ABC):
         title = title_element.text.strip() if title_element else "Untitled"
 
         # Subtitle
-        subtitle_element = soup.select_one("h3.subtitle")
+        subtitle_element = soup.select_one("h3.subtitle, div.subtitle-HEEcLo")
         subtitle = subtitle_element.text.strip() if subtitle_element else ""
 
         # Date — try CSS selector first
         date = ""
-        date_element = soup.select_one("div.pencraft.pc-reset.color-pub-secondary-text-hGQ02T")
+        date_element = soup.select_one("div.meta-EgzBVA")
         if date_element and date_element.text.strip():
             date = date_element.text.strip()
 
@@ -287,7 +287,7 @@ class BaseSubstackScraper(ABC):
             date = "Date not found"
 
         # Like count
-        like_count_element = soup.select_one("a.post-ufi-button .label")
+        like_count_element = soup.select_one('div.like-button-container button div.label')
         like_count = (
             like_count_element.text.strip()
             if like_count_element and like_count_element.text.strip().isdigit()


### PR DESCRIPTION
Computer Enhance now uses a div for the subtitle for example (other substacks still seem to use the h3, so I included both options).
Unfortunately that subtitle uses the same classes as the date element, so the selector broke. This new one works (on all blogs I tested it), though it probably is brittle, too.
Like count button has changed as well.